### PR TITLE
Fix concurrent error when creating methods

### DIFF
--- a/tasks/apigateway_deploy.js
+++ b/tasks/apigateway_deploy.js
@@ -188,7 +188,7 @@ module.exports = function (grunt) {
             }
 
             // Create methods
-            async.forEachOf(setup.methods || {}, function(methodSetup, method, callback) {
+            async.forEachOfSeries(setup.methods || {}, function(methodSetup, method, callback) {
                 _createResourceMethodRequest(resource, method, methodSetup, callback);
             }, function(err) {
                 callback(err, resource);


### PR DESCRIPTION
I've used this lib after a while and noticed the same error described at https://github.com/spreaker/grunt-aws-apigateway/pull/2. Switching the last remaingin `forEachOf` to be a `forEachOfSeries` solved the problem locally. I remember experiencing this a couple of months ago, but I just fixed locally forgetting to make the PR.
