### PR TITLE
Updated dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+#### 0.0.8 (2019-10-23)
+* Updated dependencies (see PR [#6](https://github.com/spreaker/grunt-aws-apigateway/pull/6), thanks to [Matteo Rossi](https://github.com/teorossi82))
+
 #### 0.0.7 (2016-09-20)
 * FIX: `concurrent modification` error when creating methods (see PR [#5](https://github.com/spreaker/grunt-aws-apigateway/pull/5), thanks to [Tomas Romero](https://github.com/taromero))
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "async": "^1.5.0",
-    "aws-sdk": "^2.2.20",
-    "underscore": "^1.8.3"
+    "aws-sdk": "^2.554.0",
+    "underscore": "^1.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-aws-apigateway",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A grunt plugin to easily configure and deploy AWS API Gateway.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Old version of `aws-sdk` caused errors in `Apis` used for resources creation because don't had retry strategy in the `ApiGateway` methods.
So I've updated it and used this opportunity to update other dependencies too.

I've tested the plugin in an internal project and all worked fine.